### PR TITLE
Fix a few links in the "Getting started" notebook

### DIFF
--- a/1-Getting_started/01_Getting_Started_completed.ipynb
+++ b/1-Getting_started/01_Getting_Started_completed.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "This tutorial introduces you to the syntax of hyperspy and shows you how to load, save and visualise data with HyperSpy as well as other basic functionalities, such as using indexing and regions of interest.\n",
     "\n",
-    "Although not strictly required, some knowledge of Python can help with getting the most out of HyperSpy. If you are new to Python, the [official tutorial](https://docs.python.org/2/tutorial/index.html) is an excellent way to start.\n",
+    "Although not strictly required, some knowledge of Python can help with getting the most out of HyperSpy. If you are new to Python, the [official tutorial](https://docs.python.org/3/tutorial/index.html) is an excellent way to start.\n",
     "\n",
     "This tutorial can be enjoyed interactively thanks to the [Jupyter Notebook](http://jupyter.org) and [IPython](http://ipython.org). If you are not familiar with the Jupyter Notebook, having a look at the `Help` menu above and the [IPython documentation](http://ipython.readthedocs.io/en/stable/interactive/index.html) is highly recommended.\n",
     "\n",
@@ -23,7 +23,7 @@
     "By going through this notebook, you should be able to:\n",
     "* import libraries\n",
     "* read information from docstrings\n",
-    "* Use autocompletion\n",
+    "* use autocompletion\n",
     "* discover functions and method\n",
     "* create hyperspy signals\n",
     "* load data from file\n",
@@ -82,7 +82,7 @@
     "\n",
     "**NOTE:** A \"backend\" in this context refers to the code determining the way in which the plotted data will be displayed. In the online version of this document we use the `widget` backend that displays interactive figures inside the Jupyter Notebook. Other backends, such as `qt` or `tk` can be used. If you get an error message, it is most likely that the selected backend is not available on your system.\n",
     "\n",
-    "For more detailed explanation on the compatibility of the different matplotlib backends with the HyperSpy GUIs, read the [starting HyperSpy in the notebook](http://hyperspy.org/hyperspy-doc/current/user_guide/getting_started.html#starting-hyperspy-in-the-notebook-or-terminal) section of the documentation."
+    "For more detailed explanation on the compatibility of the different matplotlib backends with the HyperSpy GUIs, read the [starting HyperSpy in the notebook](https://hyperspy.org/hyperspy-doc/current/user_guide/basic_usage.html#starting-hyperspy-in-the-notebook-or-terminal) section of the documentation."
    ]
   },
   {
@@ -119,7 +119,7 @@
     "\n",
     "* The [User Guide](http://hyperspy.org/hyperspy-doc/current/index.html)\n",
     "* The docstrings (see below)\n",
-    "* The [demos](http://nbviewer.jupyter.org/github/hyperspy/hyperspy-demos/tree/master/) such as this one.\n",
+    "* The [demos](https://nbviewer.org/github/hyperspy/hyperspy-demos/tree/main/) such as this one.\n",
     "* The [gitter chat](https://gitter.im/hyperspy/hyperspy)  \n",
     "\n",
     "\n",

--- a/1-Getting_started/01_Getting_Started_unfilled.ipynb
+++ b/1-Getting_started/01_Getting_Started_unfilled.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "This tutorial introduces you to the syntax of hyperspy and shows you how to load, save and visualise data with HyperSpy as well as other basic functionalities, such as using indexing and regions of interest.\n",
     "\n",
-    "Although not strictly required, some knowledge of Python can help with getting the most out of HyperSpy. If you are new to Python, the [official tutorial](https://docs.python.org/2/tutorial/index.html) is an excellent way to start.\n",
+    "Although not strictly required, some knowledge of Python can help with getting the most out of HyperSpy. If you are new to Python, the [official tutorial](https://docs.python.org/3/tutorial/index.html) is an excellent way to start.\n",
     "\n",
     "This tutorial can be enjoyed interactively thanks to the [Jupyter Notebook](http://jupyter.org) and [IPython](http://ipython.org). If you are not familiar with the Jupyter Notebook, having a look at the `Help` menu above and the [IPython documentation](http://ipython.readthedocs.io/en/stable/interactive/index.html) is highly recommended.\n",
     "\n",
@@ -23,7 +23,7 @@
     "By going through this notebook, you should be able to:\n",
     "* import libraries\n",
     "* read information from docstrings\n",
-    "* Use autocompletion\n",
+    "* use autocompletion\n",
     "* discover functions and method\n",
     "* create hyperspy signals\n",
     "* load data from file\n",
@@ -82,7 +82,7 @@
     "\n",
     "**NOTE:** A \"backend\" in this context refers to the code determining the way in which the plotted data will be displayed. In the online version of this document we use the `widget` backend that displays interactive figures inside the Jupyter Notebook. Other backends, such as `qt` or `tk` can be used. If you get an error message, it is most likely that the selected backend is not available on your system.\n",
     "\n",
-    "For more detailed explanation on the compatibility of the different matplotlib backends with the HyperSpy GUIs, read the [starting HyperSpy in the notebook](http://hyperspy.org/hyperspy-doc/current/user_guide/getting_started.html#starting-hyperspy-in-the-notebook-or-terminal) section of the documentation."
+    "For more detailed explanation on the compatibility of the different matplotlib backends with the HyperSpy GUIs, read the [starting HyperSpy in the notebook](https://hyperspy.org/hyperspy-doc/current/user_guide/basic_usage.html#starting-hyperspy-in-the-notebook-or-terminal) section of the documentation."
    ]
   },
   {
@@ -118,7 +118,7 @@
     "\n",
     "* The [User Guide](http://hyperspy.org/hyperspy-doc/current/index.html)\n",
     "* The docstrings (see below)\n",
-    "* The [demos](http://nbviewer.jupyter.org/github/hyperspy/hyperspy-demos/tree/master/) such as this one.\n",
+    "* The [demos](https://nbviewer.org/github/hyperspy/hyperspy-demos/tree/main/) such as this one.\n",
     "* The [gitter chat](https://gitter.im/hyperspy/hyperspy)  \n",
     "\n",
     "\n",


### PR DESCRIPTION
Changed three links in the "Getting started" notebook: two now do not return 404 anymore, while a user is guided to the Python 3 instead of Python 2 tutorial.